### PR TITLE
Commit changes introduced by version 0.5.2

### DIFF
--- a/log.cabal
+++ b/log.cabal
@@ -1,5 +1,5 @@
 name:                log
-version:             0.5.1
+version:             0.5.2
 synopsis:            Structured logging solution with multiple backends
 
 description:         A library that provides a way to record structured log messages with multiple backends.
@@ -8,13 +8,15 @@ description:         A library that provides a way to record structured log mess
                      .
                      * standard output
                      .
+                     * Elasticsearch
+                     .
                      * PostgreSQL
 
 homepage:            https://github.com/scrive/log
 license:             BSD3
 license-file:        LICENSE
 author:              Scrive
-maintainer:          Andrzej Rybczak <andrzej@rybczak.net>
+maintainer:          Andrzej Rybczak <andrzej@rybczak.net>, Jonathan Jouty <jonathan@scrive.com>
 category:            System
 build-type:          Simple
 cabal-version:       >=1.10

--- a/src/Log/Backend/StandardOutput.hs
+++ b/src/Log/Backend/StandardOutput.hs
@@ -1,10 +1,22 @@
-module Log.Backend.StandardOutput (stdoutLogger) where
+module Log.Backend.StandardOutput (
+    simpleStdoutLogger
+  , stdoutLogger
+  ) where
 
 import Prelude
 import qualified Data.Text.IO as T
 
 import Log.Data
+import Log.Internal.Logger
 import Log.Logger
+
+-- | Simple, synchronous logger that prints messages to standard output.
+simpleStdoutLogger :: Logger
+simpleStdoutLogger = Logger {
+    loggerWriteMessage = T.putStrLn . showLogMessage Nothing
+  , loggerWaitForWrite = return ()
+  , loggerFinalizers   = []
+  }
 
 -- | Create logger that prints messages to standard output.
 stdoutLogger :: IO Logger


### PR DESCRIPTION
Git repository was not updated when the package was bumped on Hackage.
Synced by downloading source from
https://hackage.haskell.org/package/log-0.5.2