### PR TITLE
Add toEncoding, and few Aeson instances

### DIFF
--- a/log.cabal
+++ b/log.cabal
@@ -44,7 +44,7 @@ library
                        Log.Monad
 
   build-depends:       base <5,
-                       aeson >=0.6.2.0,
+                       aeson >=0.11.0.0,
                        aeson-pretty >=0.8.2,
                        base64-bytestring,
                        bloodhound >= 0.11.1,


### PR DESCRIPTION
I didn't touch the instance in `ElasticSearch.hs`. It's a bit tricky with `aeson-0.11`, much easier with `1.0`. OTOH, if @23Skidoo is working on #14, maybe it's easier to do after.