### PR TITLE
Add Basic Auth and HTTPS support to Elasticsearch

### DIFF
--- a/log-elasticsearch/log-elasticsearch.cabal
+++ b/log-elasticsearch/log-elasticsearch.cabal
@@ -34,6 +34,7 @@ library
                        bloodhound >= 0.11.1,
                        deepseq,
                        http-client,
+                       http-client-tls,
                        semigroups,
                        text,
                        text-show >= 2,

--- a/log-elasticsearch/src/Log/Backend/ElasticSearch.hs
+++ b/log-elasticsearch/src/Log/Backend/ElasticSearch.hs
@@ -25,6 +25,7 @@ import Database.Bloodhound hiding (Status)
 import Log
 import Log.Internal.Logger
 import Network.HTTP.Client
+import Network.HTTP.Client.TLS (tlsManagerSettings)
 import Prelude
 import TextShow
 import qualified Data.ByteString as BS
@@ -182,7 +183,7 @@ elasticSearchLogger ElasticSearchConfig{..} genRandomWord = do
 
     runBH_ :: forall r. BH IO r -> IO r
     runBH_ f = do
-      mgr <- newManager defaultManagerSettings
+      mgr <- newManager tlsManagerSettings
       let hook = maybe return (uncurry basicAuthHook) esLogin
       let env = (mkBHEnv server mgr) { bhRequestHook = hook }
       runBH env f


### PR DESCRIPTION
We use https://www.elastic.co/cloud/as-a-service for logging, so we need HTTPS and Basic Auth in order to send logs there.