### PR TITLE
Expose connection and password checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,8 +87,8 @@ install:
  - rm -fv cabal.project.local
  - "echo 'packages: log-base, log-postgres, log-elasticsearch' > cabal.project"
  - rm -f cabal.project.freeze
- - cabal new-build -w ${HC} ${TEST} ${BENCH} --dep -j2 all
- - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --dep -j2 all
+ - cabal new-build -w ${HC} ${TEST} ${BENCH} --dep -j1 all
+ - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --dep -j1 all
 
 # Here starts the actual work to be performed for the package under test;
 # any command which exits with a non-zero exit code causes the build to fail.

--- a/log-elasticsearch/CHANGELOG.md
+++ b/log-elasticsearch/CHANGELOG.md
@@ -1,3 +1,6 @@
+# log-elasticsearch-0.10.1.0 (2018-03-23)
+* expose `checkElasticSearchConnection` and `checkElasticSearchLogin`
+	
 # log-elasticsearch-0.10.0.0 (2018-03-06)
 * Add config parameters for number of shards and replicas to 'ElasticSearchConfig'
   (and make default of 4 shards and 1 replica explicit in 'defaultElasticSearchConfig').

--- a/log-elasticsearch/log-elasticsearch.cabal
+++ b/log-elasticsearch/log-elasticsearch.cabal
@@ -1,5 +1,5 @@
 name:                log-elasticsearch
-version:             0.10.0.0
+version:             0.10.1.0
 synopsis:            Structured logging solution (Elasticsearch back end)
 
 description:         Elasticsearch back end for the 'log' library suite.

--- a/log-elasticsearch/src/Log/Backend/ElasticSearch/V1.hs
+++ b/log-elasticsearch/src/Log/Backend/ElasticSearch/V1.hs
@@ -70,13 +70,13 @@ elasticSearchLogger ::
   -> IO Word32        -- ^ Generate a random 32-bit word for use in
                       -- document IDs.
   -> IO Logger
-elasticSearchLogger ElasticSearchConfig{..} genRandomWord = do
+elasticSearchLogger esConf@ElasticSearchConfig{..} genRandomWord = do
 
-  checkElasticSearchLogin ElasticSearchConfig{..} >>= \case
+  checkElasticSearchLogin esConf >>= \case
     Left (ex :: IOException) -> error . show $ ex
     Right _ -> return ()
 
-  checkElasticSearchConnection ElasticSearchConfig{..} >>= \case
+  checkElasticSearchConnection esConf >>= \case
       Left (ex :: HttpException) ->
         hPutStrLn stderr $
                   "ElasticSearch: unexpected error: " <>
@@ -95,7 +95,7 @@ elasticSearchLogger ElasticSearchConfig{..} genRandomWord = do
     baseID <- (<>)
       <$> (littleEndianRep <$> liftIO genRandomWord)
       <*> pure (littleEndianRep . floor $ timeToDouble now)
-    retryOnException . runBH_ ElasticSearchConfig{..} $ do
+    retryOnException . runBH_ esConf $ do
       -- Elasticsearch index names are additionally indexed by date so that each
       -- day is logged to a separate index to make log management easier.
       let index = IndexName $ T.concat [
@@ -109,7 +109,8 @@ elasticSearchLogger ElasticSearchConfig{..} genRandomWord = do
         -- index that already exists is harmless.
         indexExists' <- indexExists index
         unless indexExists' $ do
-          -- Note that Bloodhound won't let us create index using default settings
+          -- Note that Bloodhound won't let us create index using
+          -- default settings.
           let indexSettings = IndexSettings {
                   indexShards   = ShardCount esShardCount
                 , indexReplicas = ReplicaCount esReplicaCount
@@ -161,7 +162,7 @@ elasticSearchLogger ElasticSearchConfig{..} genRandomWord = do
     elasticSearchSync :: IORef IndexName -> IO ()
     elasticSearchSync indexRef = do
       indexName <- readIORef indexRef
-      void . runBH_ ElasticSearchConfig{..} $ refreshIndex indexName
+      void . runBH_ esConf $ refreshIndex indexName
 
     retryOnException :: forall r. IO r -> IO r
     retryOnException m = try m >>= \case
@@ -280,8 +281,8 @@ checkElasticSearchLogin ElasticSearchConfig{..} =
         <> "Set esLoginInsecure = True to disable this check."
 
 checkElasticSearchConnection :: ElasticSearchConfig -> IO (Either HttpException ())
-checkElasticSearchConnection ElasticSearchConfig{..} =
-    try (void $ runBH_ ElasticSearchConfig{..} listIndices)
+checkElasticSearchConnection esConf =
+    try (void $ runBH_ esConf listIndices)
 
 runBH_ :: forall r. ElasticSearchConfig -> BH IO r -> IO r
 runBH_ ElasticSearchConfig{..} f = do

--- a/log-elasticsearch/src/Log/Backend/ElasticSearch/V1.hs
+++ b/log-elasticsearch/src/Log/Backend/ElasticSearch/V1.hs
@@ -6,6 +6,8 @@ module Log.Backend.ElasticSearch.V1 (
   , esMapping
   , esLogin
   , esLoginInsecure
+  , checkElasticSearchLogin
+  , checkElasticSearchConnection
   , defaultElasticSearchConfig
   , withElasticSearchLogger
   , elasticSearchLogger
@@ -69,8 +71,19 @@ elasticSearchLogger ::
                       -- document IDs.
   -> IO Logger
 elasticSearchLogger ElasticSearchConfig{..} genRandomWord = do
-  checkElasticSearchLogin
-  checkElasticSearchConnection
+
+  checkElasticSearchLogin ElasticSearchConfig{..} >>= \case
+    Left (ex :: IOException) -> error . show $ ex
+    Right _ -> return ()
+
+  checkElasticSearchConnection ElasticSearchConfig{..} >>= \case
+      Left (ex :: HttpException) ->
+        hPutStrLn stderr $
+                  "ElasticSearch: unexpected error: " <>
+                  show ex <>
+                  " (is ElasticSearch server running?)"
+      Right () -> return ()
+
   indexRef <- newIORef $ IndexName T.empty
   mkBulkLogger "ElasticSearch" (\msgs -> do
     now <- getCurrentTime
@@ -82,7 +95,7 @@ elasticSearchLogger ElasticSearchConfig{..} genRandomWord = do
     baseID <- (<>)
       <$> (littleEndianRep <$> liftIO genRandomWord)
       <*> pure (littleEndianRep . floor $ timeToDouble now)
-    retryOnException . runBH_ $ do
+    retryOnException . runBH_ ElasticSearchConfig{..} $ do
       -- Elasticsearch index names are additionally indexed by date so that each
       -- day is logged to a separate index to make log management easier.
       let index = IndexName $ T.concat [
@@ -143,29 +156,12 @@ elasticSearchLogger ElasticSearchConfig{..} genRandomWord = do
           void $ bulk (V.map (toBulk index baseID) dummyMsgs))
     (elasticSearchSync indexRef)
   where
-    server  = Server esServer
     mapping = MappingName esMapping
 
     elasticSearchSync :: IORef IndexName -> IO ()
     elasticSearchSync indexRef = do
       indexName <- readIORef indexRef
-      void . runBH_ $ refreshIndex indexName
-
-    checkElasticSearchLogin :: IO ()
-    checkElasticSearchLogin =
-      when (isJust esLogin
-            && not esLoginInsecure
-            && not ("https:" `T.isPrefixOf` esServer)) $
-        error $ "ElasticSearch: insecure login: "
-          <> "Attempting to send login credentials over an insecure connection. "
-          <> "Set esLoginInsecure = True to disable this check."
-
-    checkElasticSearchConnection :: IO ()
-    checkElasticSearchConnection = try (void $ runBH_ listIndices) >>= \case
-      Left (ex::HttpException) ->
-        hPutStrLn stderr $ "ElasticSearch: unexpected error: " <> show ex
-          <> " (is ElasticSearch server running?)"
-      Right () -> return ()
+      void . runBH_ ElasticSearchConfig{..} $ refreshIndex indexName
 
     retryOnException :: forall r. IO r -> IO r
     retryOnException m = try m >>= \case
@@ -178,14 +174,6 @@ elasticSearchLogger ElasticSearchConfig{..} genRandomWord = do
 
     timeToDouble :: UTCTime -> Double
     timeToDouble = realToFrac . utcTimeToPOSIXSeconds
-
-    runBH_ :: forall r. BH IO r -> IO r
-    runBH_ f = do
-      mgr <- newManager tlsManagerSettings
-      let hook = maybe return (uncurry basicAuthHook) esLogin
-      let env = (mkBHEnv server mgr) { bhRequestHook = hook }
-      runBH env f
-
 
     jsonToBSL :: Value -> BSL.ByteString
     jsonToBSL = encodePretty' defConfig { confIndent = Spaces 2 }
@@ -280,3 +268,24 @@ decodeReply :: Reply -> Value
 decodeReply reply = case eitherDecode' $ responseBody reply of
   Right body -> body
   Left  err  -> object ["decoding_error" .= err]
+
+checkElasticSearchLogin :: ElasticSearchConfig -> IO (Either IOException ())
+checkElasticSearchLogin ElasticSearchConfig{..} =
+  try $
+    when (isJust esLogin
+          && not esLoginInsecure
+          && not ("https:" `T.isPrefixOf` esServer)) $
+      error $ "ElasticSearch: insecure login: "
+        <> "Attempting to send login credentials over an insecure connection. "
+        <> "Set esLoginInsecure = True to disable this check."
+
+checkElasticSearchConnection :: ElasticSearchConfig -> IO (Either HttpException ())
+checkElasticSearchConnection ElasticSearchConfig{..} =
+    try (void $ runBH_ ElasticSearchConfig{..} listIndices)
+
+runBH_ :: forall r. ElasticSearchConfig -> BH IO r -> IO r
+runBH_ ElasticSearchConfig{..} f = do
+  mgr <- newManager tlsManagerSettings
+  let hook = maybe return (uncurry basicAuthHook) esLogin
+  let env = (mkBHEnv (Server esServer) mgr) { bhRequestHook = hook }
+  runBH env f

--- a/log-elasticsearch/src/Log/Backend/ElasticSearch/V5.hs
+++ b/log-elasticsearch/src/Log/Backend/ElasticSearch/V5.hs
@@ -6,6 +6,8 @@ module Log.Backend.ElasticSearch.V5 (
   , esMapping
   , esLogin
   , esLoginInsecure
+  , checkElasticSearchLogin
+  , checkElasticSearchConnection
   , defaultElasticSearchConfig
   , withElasticSearchLogger
   , elasticSearchLogger
@@ -68,8 +70,19 @@ elasticSearchLogger ::
                       -- document IDs.
   -> IO Logger
 elasticSearchLogger ElasticSearchConfig{..} genRandomWord = do
-  checkElasticSearchLogin
-  checkElasticSearchConnection
+
+  checkElasticSearchLogin ElasticSearchConfig{..} >>= \case
+    Left (ex :: IOException) -> error . show $ ex
+    Right _ -> return ()
+
+  checkElasticSearchConnection ElasticSearchConfig{..} >>= \case
+      Left (ex :: HttpException) ->
+        hPutStrLn stderr $
+                  "ElasticSearch: unexpected error: " <>
+                  show ex <>
+                  " (is ElasticSearch server running?)"
+      Right () -> return ()
+
   indexRef <- newIORef $ IndexName T.empty
   mkBulkLogger "ElasticSearch" (\msgs -> do
     now <- getCurrentTime
@@ -81,7 +94,7 @@ elasticSearchLogger ElasticSearchConfig{..} genRandomWord = do
     baseID <- (<>)
       <$> (littleEndianRep <$> liftIO genRandomWord)
       <*> pure (littleEndianRep . floor $ timeToDouble now)
-    retryOnException . runBH_ $ do
+    retryOnException . runBH_ ElasticSearchConfig{..} $ do
       -- Elasticsearch index names are additionally indexed by date so that each
       -- day is logged to a separate index to make log management easier.
       let index = IndexName $ T.concat [
@@ -142,29 +155,12 @@ elasticSearchLogger ElasticSearchConfig{..} genRandomWord = do
           void $ bulk (V.map (toBulk index baseID) dummyMsgs))
     (elasticSearchSync indexRef)
   where
-    server  = Server esServer
     mapping = MappingName esMapping
 
     elasticSearchSync :: IORef IndexName -> IO ()
     elasticSearchSync indexRef = do
       indexName <- readIORef indexRef
-      void . runBH_ $ refreshIndex indexName
-
-    checkElasticSearchLogin :: IO ()
-    checkElasticSearchLogin =
-      when (isJust esLogin
-            && not esLoginInsecure
-            && not ("https:" `T.isPrefixOf` esServer)) $
-        error $ "ElasticSearch: insecure login: "
-          <> "Attempting to send login credentials over an insecure connection. "
-          <> "Set esLoginInsecure = True to disable this check."
-
-    checkElasticSearchConnection :: IO ()
-    checkElasticSearchConnection = try (void $ runBH_ listIndices) >>= \case
-      Left (ex::HttpException) ->
-        hPutStrLn stderr $ "ElasticSearch: unexpected error: " <> show ex
-          <> " (is ElasticSearch server running?)"
-      Right () -> return ()
+      void . runBH_ ElasticSearchConfig{..} $ refreshIndex indexName
 
     retryOnException :: forall r. IO r -> IO r
     retryOnException m = try m >>= \case
@@ -177,14 +173,6 @@ elasticSearchLogger ElasticSearchConfig{..} genRandomWord = do
 
     timeToDouble :: UTCTime -> Double
     timeToDouble = realToFrac . utcTimeToPOSIXSeconds
-
-    runBH_ :: forall r. BH IO r -> IO r
-    runBH_ f = do
-      mgr <- newManager tlsManagerSettings
-      let hook = maybe return (uncurry basicAuthHook) esLogin
-      let env = (mkBHEnv server mgr) { bhRequestHook = hook }
-      runBH env f
-
 
     jsonToBSL :: Value -> BSL.ByteString
     jsonToBSL = encodePretty' defConfig { confIndent = Spaces 2 }
@@ -251,3 +239,24 @@ decodeReply :: Reply -> Value
 decodeReply reply = case eitherDecode' $ responseBody reply of
   Right body -> body
   Left  err  -> object ["decoding_error" .= err]
+
+checkElasticSearchLogin :: ElasticSearchConfig -> IO (Either IOException ())
+checkElasticSearchLogin ElasticSearchConfig{..} =
+  try $
+    when (isJust esLogin
+          && not esLoginInsecure
+          && not ("https:" `T.isPrefixOf` esServer)) $
+      error $ "ElasticSearch: insecure login: "
+        <> "Attempting to send login credentials over an insecure connection. "
+        <> "Set esLoginInsecure = True to disable this check."
+
+checkElasticSearchConnection :: ElasticSearchConfig -> IO (Either HttpException ())
+checkElasticSearchConnection ElasticSearchConfig{..} =
+    try (void $ runBH_ ElasticSearchConfig{..} listIndices)
+
+runBH_ :: forall r. ElasticSearchConfig -> BH IO r -> IO r
+runBH_ ElasticSearchConfig{..} f = do
+  mgr <- newManager tlsManagerSettings
+  let hook = maybe return (uncurry basicAuthHook) esLogin
+  let env = (mkBHEnv (Server esServer) mgr) { bhRequestHook = hook }
+  runBH env f


### PR DESCRIPTION
Another one for you, @23Skidoo.

This is exposing `checkElasticSearchConnection` and `checkElasticSearchLogin` for the benefit of client programmers (in this case me - needed at work).

Forgot changelog - fixing. (Edit: fixed).