### PR TITLE
Replace deprecated "string" type in ES V5

### DIFF
--- a/log-elasticsearch-copy.sh
+++ b/log-elasticsearch-copy.sh
@@ -2,7 +2,7 @@
 set -ex
 
 DIR=log-elasticsearch/src/Log/Backend/ElasticSearch/
-FILES="$DIR/V1/Lens.hs $DIR/V1/Internal.hs"
+FILES="$DIR/V1/Lens.hs $DIR/V1/Internal.hs $DIR/V1.hs"
 
 for SRC in $FILES; do
     DEST=$(echo $SRC|sed s/V1/V5/)

--- a/log-elasticsearch-copy.sh
+++ b/log-elasticsearch-copy.sh
@@ -7,5 +7,5 @@ FILES="$DIR/V1/Lens.hs $DIR/V1/Internal.hs $DIR/V1.hs"
 for SRC in $FILES; do
     DEST=$(echo $SRC|sed s/V1/V5/)
 
-    cat $SRC | sed s/V1/V5/ > $DEST
+    cat $SRC | sed s/V1/V5/ | sed s/"string"/"text"/ > $DEST
 done

--- a/log-elasticsearch-copy.sh
+++ b/log-elasticsearch-copy.sh
@@ -2,7 +2,7 @@
 set -ex
 
 DIR=log-elasticsearch/src/Log/Backend/ElasticSearch/
-FILES="$DIR/V1/Lens.hs $DIR/V1/Internal.hs $DIR/V1.hs"
+FILES="$DIR/V1/Lens.hs $DIR/V1/Internal.hs"
 
 for SRC in $FILES; do
     DEST=$(echo $SRC|sed s/V1/V5/)

--- a/log-elasticsearch/CHANGELOG.md
+++ b/log-elasticsearch/CHANGELOG.md
@@ -1,3 +1,6 @@
+# log-elasticsearch-0.10.0.1 (2019-01-14)
+* Compatibility with ES 6.x by using "text" instead of deprecated "string"
+
 # log-elasticsearch-0.10.0.0 (2018-03-28)
 * Expose `checkElasticSearchConnection` and `checkElasticSearchLogin`.
 * Add config parameters for number of shards and replicas to

--- a/log-elasticsearch/src/Log/Backend/ElasticSearch/V5.hs
+++ b/log-elasticsearch/src/Log/Backend/ElasticSearch/V5.hs
@@ -218,20 +218,16 @@ instance ToJSON LogsMapping where
           , "format" .= ("date_time"::T.Text)
           ]
         , "domain" .= object [
-            "type" .= ("text"::T.Text)
-          , "index" .= True
+            "type" .= ("string"::T.Text)
           ]
         , "level" .= object [
-            "type" .= ("text"::T.Text)
-          , "index" .= True
+            "type" .= ("string"::T.Text)
           ]
         , "component" .= object [
-            "type" .= ("text"::T.Text)
-          , "index" .= True
+            "type" .= ("string"::T.Text)
           ]
         , "message" .= object [
-            "type" .= ("text"::T.Text)
-          , "index" .= True
+            "type" .= ("string"::T.Text)
           ]
         ]
     ]
@@ -250,20 +246,16 @@ instance ToJSON LogsMapping where
         , "format" .= ("date_time"::T.Text)
         ]
       , Aeson.pair "domain" $ Aeson.pairs $ mconcat
-        [ "type" .= ("text"::T.Text)
-        , "index" .= True
+        [ "type" .= ("string"::T.Text)
         ]
       , Aeson.pair "level" $ Aeson.pairs $ mconcat
-        [ "type" .= ("text"::T.Text)
-        , "index" .= True
+        [ "type" .= ("string"::T.Text)
         ]
       , Aeson.pair "component" $ Aeson.pairs $ mconcat
-        [ "type" .= ("text"::T.Text)
-        , "index" .= True
+        [ "type" .= ("string"::T.Text)
         ]
       , Aeson.pair "message" $ Aeson.pairs $ mconcat
-        [ "type" .= ("text"::T.Text)
-        , "index" .= True
+        [ "type" .= ("string"::T.Text)
         ]
       ]
     ]

--- a/log-elasticsearch/src/Log/Backend/ElasticSearch/V5.hs
+++ b/log-elasticsearch/src/Log/Backend/ElasticSearch/V5.hs
@@ -218,16 +218,20 @@ instance ToJSON LogsMapping where
           , "format" .= ("date_time"::T.Text)
           ]
         , "domain" .= object [
-            "type" .= ("string"::T.Text)
+            "type" .= ("text"::T.Text)
+          , "index" .= True
           ]
         , "level" .= object [
-            "type" .= ("string"::T.Text)
+            "type" .= ("text"::T.Text)
+          , "index" .= True
           ]
         , "component" .= object [
-            "type" .= ("string"::T.Text)
+            "type" .= ("text"::T.Text)
+          , "index" .= True
           ]
         , "message" .= object [
-            "type" .= ("string"::T.Text)
+            "type" .= ("text"::T.Text)
+          , "index" .= True
           ]
         ]
     ]
@@ -246,16 +250,20 @@ instance ToJSON LogsMapping where
         , "format" .= ("date_time"::T.Text)
         ]
       , Aeson.pair "domain" $ Aeson.pairs $ mconcat
-        [ "type" .= ("string"::T.Text)
+        [ "type" .= ("text"::T.Text)
+        , "index" .= True
         ]
       , Aeson.pair "level" $ Aeson.pairs $ mconcat
-        [ "type" .= ("string"::T.Text)
+        [ "type" .= ("text"::T.Text)
+        , "index" .= True
         ]
       , Aeson.pair "component" $ Aeson.pairs $ mconcat
-        [ "type" .= ("string"::T.Text)
+        [ "type" .= ("text"::T.Text)
+        , "index" .= True
         ]
       , Aeson.pair "message" $ Aeson.pairs $ mconcat
-        [ "type" .= ("string"::T.Text)
+        [ "type" .= ("text"::T.Text)
+        , "index" .= True
         ]
       ]
     ]

--- a/log-elasticsearch/src/Log/Backend/ElasticSearch/V5.hs
+++ b/log-elasticsearch/src/Log/Backend/ElasticSearch/V5.hs
@@ -218,16 +218,16 @@ instance ToJSON LogsMapping where
           , "format" .= ("date_time"::T.Text)
           ]
         , "domain" .= object [
-            "type" .= ("string"::T.Text)
+            "type" .= ("text"::T.Text)
           ]
         , "level" .= object [
-            "type" .= ("string"::T.Text)
+            "type" .= ("text"::T.Text)
           ]
         , "component" .= object [
-            "type" .= ("string"::T.Text)
+            "type" .= ("text"::T.Text)
           ]
         , "message" .= object [
-            "type" .= ("string"::T.Text)
+            "type" .= ("text"::T.Text)
           ]
         ]
     ]
@@ -246,16 +246,16 @@ instance ToJSON LogsMapping where
         , "format" .= ("date_time"::T.Text)
         ]
       , Aeson.pair "domain" $ Aeson.pairs $ mconcat
-        [ "type" .= ("string"::T.Text)
+        [ "type" .= ("text"::T.Text)
         ]
       , Aeson.pair "level" $ Aeson.pairs $ mconcat
-        [ "type" .= ("string"::T.Text)
+        [ "type" .= ("text"::T.Text)
         ]
       , Aeson.pair "component" $ Aeson.pairs $ mconcat
-        [ "type" .= ("string"::T.Text)
+        [ "type" .= ("text"::T.Text)
         ]
       , Aeson.pair "message" $ Aeson.pairs $ mconcat
-        [ "type" .= ("string"::T.Text)
+        [ "type" .= ("text"::T.Text)
         ]
       ]
     ]


### PR DESCRIPTION
According to the section "How to migrate" in https://www.elastic.co/blog/strings-are-dead-long-live-strings and the information here https://www.elastic.co/guide/en/elasticsearch/reference/5.5/mapping-index.html this should be equivalent to the current behaviour.

Closes #44 