### PR TITLE
Add getLoggerIO to MonadLog class

### DIFF
--- a/log-base/CHANGELOG.md
+++ b/log-base/CHANGELOG.md
@@ -1,3 +1,6 @@
+# log-base-0.8.0.0 (2019-04-02)
+* Add `getLoggerEnv` function to `MonadLog` class, add `getLoggerIO` utility.
+
 # log-base-0.7.4.0 (2017-10-27)
 * Add `mkBulkLogger'` ([#40](https://github.com/scrive/log/pull/40).
 

--- a/log-base/log-base.cabal
+++ b/log-base/log-base.cabal
@@ -1,5 +1,5 @@
 name:                log-base
-version:             0.7.4.0
+version:             0.8.0.0
 synopsis:            Structured logging solution (base package)
 
 description:         A library that provides a way to record structured log

--- a/log-base/src/Log/Class.hs
+++ b/log-base/src/Log/Class.hs
@@ -23,6 +23,7 @@ import Prelude
 import qualified Data.Text as T
 
 import Log.Data
+import Log.Logger
 
 -- | Represents the family of monads with logging capabilities. Each
 -- 'MonadLog' carries with it some associated state (the logging
@@ -39,6 +40,9 @@ class MonadTime m => MonadLog m where
   localData   :: [Pair] -> m a -> m a
   -- | Extend the current application domain locally.
   localDomain :: T.Text -> m a -> m a
+  -- | Get current 'LoggerEnv' object. Useful for construction of logging
+  -- functions that work in a different monad, see 'getLoggerIO' as an example.
+  getLoggerEnv :: m LoggerEnv
 
 -- | Generic, overlapping instance.
 instance (
@@ -49,6 +53,7 @@ instance (
     logMessage time level message = lift . logMessage time level message
     localData data_ m = controlT $ \run -> localData data_ (run m)
     localDomain domain m = controlT $ \run -> localDomain domain (run m)
+    getLoggerEnv = lift getLoggerEnv
 
 controlT :: (MonadTransControl t, Monad (t m), Monad m)
          => (Run t -> m (StT t a)) -> t m a

--- a/log-base/src/Log/Logger.hs
+++ b/log-base/src/Log/Logger.hs
@@ -1,6 +1,7 @@
 -- | The 'Logger' type of logging back-ends.
-module Log.Logger (
-    Logger
+module Log.Logger
+  ( LoggerEnv(..)
+  , Logger
   , mkLogger
   , mkBulkLogger
   , mkBulkLogger'
@@ -16,11 +17,21 @@ import Control.Exception
 import Control.Monad
 import Data.Semigroup
 import Prelude
+import qualified Data.Aeson.Types as A
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 
 import Log.Data
 import Log.Internal.Logger
+
+-- | The state that every 'LogT' carries around.
+data LoggerEnv = LoggerEnv
+  { leLogger    :: !Logger   -- ^ The 'Logger' to use.
+  , leComponent :: !T.Text   -- ^ Current application component.
+  , leDomain    :: ![T.Text] -- ^ Current application domain.
+  , leData      :: ![A.Pair] -- ^ Additional data to be merged with the log
+                             -- message\'s data.
+  }
 
 -- | Start a logger thread that consumes one queued message at a time.
 mkLogger :: T.Text -> (LogMessage -> IO ()) -> IO Logger


### PR DESCRIPTION
Needed for passing Logger to libraries such as `aws` or `amazonka` that operate in the IO monad.