### PR TITLE
Add jsonline output support to stdout logger

### DIFF
--- a/log-base/log-base.cabal
+++ b/log-base/log-base.cabal
@@ -39,6 +39,7 @@ library
                        Log.Monad
   build-depends:       base >= 4.9 && <5,
                        aeson >=0.11.0.0,
+                       aeson-pretty >=0.8.2,
                        bytestring,
                        deepseq,
                        exceptions >=0.6,

--- a/log-base/log-base.cabal
+++ b/log-base/log-base.cabal
@@ -39,7 +39,6 @@ library
                        Log.Monad
   build-depends:       base >= 4.9 && <5,
                        aeson >=0.11.0.0,
-                       aeson-pretty >=0.8.2,
                        bytestring,
                        deepseq,
                        exceptions >=0.6,

--- a/log-base/log-base.cabal
+++ b/log-base/log-base.cabal
@@ -1,5 +1,5 @@
 name:                log-base
-version:             0.8.0.1
+version:             0.8.0.2
 synopsis:            Structured logging solution (base package)
 
 description:         A library that provides a way to record structured log

--- a/log-base/src/Log/Backend/StandardOutput.hs
+++ b/log-base/src/Log/Backend/StandardOutput.hs
@@ -3,6 +3,7 @@ module Log.Backend.StandardOutput (
     simpleStdoutLogger
   , stdoutLogger
   , withSimpleStdOutLogger
+  , withSimpleJsonLineStdOutLogger
   ) where
 
 import Prelude
@@ -18,6 +19,15 @@ import Log.Logger
 withSimpleStdOutLogger :: (Logger -> IO r) -> IO r
 withSimpleStdOutLogger act = do
   logger <- stdoutLogger
+  withLogger logger act
+
+-- | Create a simple jsonline logger for the duration of the given
+-- action, making sure that stdout is flushed afterwards.
+withSimpleJsonLineStdOutLogger :: (Logger -> IO r) -> IO r
+withSimpleJsonLineStdOutLogger act = do
+  logger <- mkLogger "jsonlines-stdout" $
+                      (\msg -> (T.putStrLn . showJsonLineLogMessage Nothing $ msg)
+                                >> hFlush stdout)
   withLogger logger act
 
 {-# DEPRECATED simpleStdoutLogger "Use 'withSimpleStdOutLogger'" #-}

--- a/log-base/src/Log/Data.hs
+++ b/log-base/src/Log/Data.hs
@@ -10,7 +10,6 @@ module Log.Data (
 import Control.DeepSeq
 import Control.Applicative
 import Data.Aeson
-import Data.Aeson.Encode.Pretty
 import Data.Aeson.Types
 import Data.ByteString.Lazy (toStrict)
 import Data.Time
@@ -86,9 +85,7 @@ showLogMessage mInsertionTime LogMessage{..} = T.concat $ [
     else [" ", textifyData lmData]
   where
     textifyData :: Value -> T.Text
-    textifyData = T.decodeUtf8 . toStrict . encodePretty' defConfig {
-      confIndent = Spaces 2
-    }
+    textifyData = T.decodeUtf8 . toStrict . encode
 
 instance ToJSON LogMessage where
   toJSON LogMessage{..} = object [

--- a/log-base/src/Log/Data.hs
+++ b/log-base/src/Log/Data.hs
@@ -73,7 +73,7 @@ showLogMessage :: Maybe UTCTime -- ^ The time that message was added to the log.
 showLogMessage mInsertionTime LogMessage{..} = textifyData $ object [
     "timestamp" .= (T.pack $ formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S" lmTime)
   , "insertion_time" .=  (case mInsertionTime of
-      Nothing -> " "
+      Nothing -> ""
       Just it -> T.pack $ formatTime defaultTimeLocale " (%H:%M:%S) " it)
   , "level" .= (T.toUpper $ showLogLevel lmLevel)
   , "component" .=  (T.intercalate "/" $ lmComponent : lmDomain)

--- a/log-base/src/Log/Data.hs
+++ b/log-base/src/Log/Data.hs
@@ -70,19 +70,16 @@ data LogMessage = LogMessage {
 showLogMessage :: Maybe UTCTime -- ^ The time that message was added to the log.
                -> LogMessage    -- ^ The actual message.
                -> T.Text
-showLogMessage mInsertionTime LogMessage{..} = T.concat $ [
-    T.pack $ formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S" lmTime
-  , case mInsertionTime of
+showLogMessage mInsertionTime LogMessage{..} = textifyData $ object [
+    "timestamp" .= (T.pack $ formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S" lmTime)
+  , "insertion_time" .=  (case mInsertionTime of
       Nothing -> " "
-      Just it -> T.pack $ formatTime defaultTimeLocale " (%H:%M:%S) " it
-  , T.toUpper $ showLogLevel lmLevel
-  , " "
-  , T.intercalate "/" $ lmComponent : lmDomain
-  , ": "
-  , lmMessage
-  ] ++ if lmData == emptyObject
-    then []
-    else [" ", textifyData lmData]
+      Just it -> T.pack $ formatTime defaultTimeLocale " (%H:%M:%S) " it)
+  , "level" .= (T.toUpper $ showLogLevel lmLevel)
+  , "component" .=  (T.intercalate "/" $ lmComponent : lmDomain)
+  , "message" .= lmMessage
+  , "data" .= lmData
+  ]
   where
     textifyData :: Value -> T.Text
     textifyData = T.decodeUtf8 . toStrict . encode


### PR DESCRIPTION
While it's nice for humans to see pretty log messages and all those
indentation it's much more difficult for machine consumption.

This introduces a change from using `encodePretty'` to simple `encode`
which will produce jsonline for each log message.

In modern word of containers and K8s it is the required way for logging.

An example of how the new logging output will look like:


```json
{"component":"UDP","data":{"from":"127.0.0.1:37392","answer":"1.2.1.1","server":"ec2121e7bdd4","question":"1.2.1.1.example.com."},"insertion_time":"","message":"","timestamp":"2020-07-18 10:07:27","level":"INFO"}
```