### PR TITLE
Drop MonadTime constraint and use system time by default

### DIFF
--- a/log-base/CHANGELOG.md
+++ b/log-base/CHANGELOG.md
@@ -1,3 +1,6 @@
+# log -base-0.10.0.0 (2021-05-28)
+* Drop `MonadTime` constraint and use system time by default.
+
 # log-base-0.9.1.1 (2021-05-28)
 * Support GHC 9.0.
 

--- a/log-base/log-base.cabal
+++ b/log-base/log-base.cabal
@@ -1,5 +1,5 @@
 name:                log-base
-version:             0.9.1.1
+version:             0.10.0.0
 synopsis:            Structured logging solution (base package)
 
 description:         A library that provides a way to record structured log
@@ -47,7 +47,6 @@ library
                        exceptions >=0.6,
                        mmorph >=1.0.9 && <1.2,
                        monad-control >=0.3,
-                       monad-time >= 0.2,
                        mtl,
                        semigroups,
                        stm >=2.4,

--- a/log-elasticsearch/CHANGELOG.md
+++ b/log-elasticsearch/CHANGELOG.md
@@ -1,3 +1,6 @@
+# log-elasticsearch-0.12.0.0 (2021-05-28)
+* Stop putting `insertion_time` and `insertion_order` in ElasticSearch.
+
 # log-elasticsearch-0.11.0.0 (2020-08-24)
 * Drop dependency on bloodhound
 * Unify V1 and V5 specific modules

--- a/log-elasticsearch/log-elasticsearch.cabal
+++ b/log-elasticsearch/log-elasticsearch.cabal
@@ -1,5 +1,5 @@
 name:                log-elasticsearch
-version:             0.11.0.0
+version:             0.12.0.0
 synopsis:            Structured logging solution (Elasticsearch back end)
 
 description:         Elasticsearch back end for the 'log' library suite.
@@ -38,7 +38,7 @@ library
                        http-client,
                        http-client-tls,
                        http-types,
-                       log-base >= 0.7 && <0.10,
+                       log-base >= 0.10 && <0.11,
                        network-uri,
                        semigroups,
                        text,

--- a/log-elasticsearch/src/Log/Backend/ElasticSearch/Internal.hs
+++ b/log-elasticsearch/src/Log/Backend/ElasticSearch/Internal.hs
@@ -135,14 +135,7 @@ createIndexWithMapping version env ElasticSearchConfig{..} index = do
   where
     logsMapping = object
       [ "properties" .= object
-        [ "insertion_order" .= object
-          [ "type" .= ("integer"::T.Text)
-          ]
-        , "insertion_time" .= object
-          [ "type"   .= ("date"::T.Text)
-          , "format" .= ("date_time"::T.Text)
-          ]
-        , "time" .= object
+        [ "time" .= object
           [ "type"   .= ("date"::T.Text)
           , "format" .= ("date_time"::T.Text)
           ]

--- a/log-postgres/CHANGELOG.md
+++ b/log-postgres/CHANGELOG.md
@@ -1,3 +1,6 @@
+# log-postgres-0.8.0.0 (2021-05-28)
+* Stop putting `insertion_time` and `insertion_order` in PostgreSQL.
+
 # log-postgres-0.7.1.5 (2021-05-28)
 * Support GHC 9.0.
 

--- a/log-postgres/log-postgres.cabal
+++ b/log-postgres/log-postgres.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.0
 name:                log-postgres
-version:             0.7.1.5
+version:             0.8.0.0
 synopsis:            Structured logging solution (PostgreSQL back end)
 
 description:         PostgreSQL back end for the 'log' library suite.
@@ -36,7 +36,7 @@ library
                     , hpqtypes              >= 1.7
                     , http-client           >= 0.5
                     , lifted-base           >= 0.2
-                    , log-base              >= 0.7  && < 0.10
+                    , log-base              >= 0.10  && < 0.11
                     , mtl                   >= 2.2
                     , semigroups            >= 0.16
                     , split                 >= 0.2


### PR DESCRIPTION
Also, `insertion_time` and `insertion_order` might've been useful only if time of a log message wasn't current time, so drop them.