### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250216
+# version: 0.19.20250315
 #
-# REGENDATA ("0.19.20250216",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.19.20250315",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -32,9 +32,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.12.1
+          - compiler: ghc-9.12.2
             compilerKind: ghc
-            compilerVersion: 9.12.1
+            compilerVersion: 9.12.2
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.10.1
@@ -81,7 +81,7 @@ jobs:
       - name: Install GHCup
         run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.40.0/x86_64-linux-ghcup-0.1.40.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |

--- a/log-base/log-base.cabal
+++ b/log-base/log-base.cabal
@@ -21,7 +21,7 @@ copyright:           Scrive AB
 category:            System
 build-type:          Simple
 extra-source-files:  CHANGELOG.md, README.md
-tested-with:         GHC == { 8.10.7, 9.0.2, 9.2.8, 9.4.8, 9.6.6, 9.8.4, 9.10.1, 9.12.1 }
+tested-with:         GHC == { 8.10.7, 9.0.2, 9.2.8, 9.4.8, 9.6.6, 9.8.4, 9.10.1, 9.12.2 }
 
 source-repository head
   type:     git

--- a/log-elasticsearch/log-elasticsearch.cabal
+++ b/log-elasticsearch/log-elasticsearch.cabal
@@ -18,7 +18,7 @@ copyright:           Scrive AB
 category:            System
 build-type:          Simple
 extra-source-files:  CHANGELOG.md, README.md
-tested-with:         GHC == { 8.10.7, 9.0.2, 9.2.8, 9.4.8, 9.6.6, 9.8.4, 9.10.1, 9.12.1 }
+tested-with:         GHC == { 8.10.7, 9.0.2, 9.2.8, 9.4.8, 9.6.6, 9.8.4, 9.10.1, 9.12.2 }
 
 source-repository head
   type:     git

--- a/log-postgres/log-postgres.cabal
+++ b/log-postgres/log-postgres.cabal
@@ -18,7 +18,7 @@ copyright:           Scrive AB
 category:            System
 build-type:          Simple
 extra-source-files:  CHANGELOG.md, README.md
-tested-with:         GHC == { 8.10.7, 9.0.2, 9.2.8, 9.4.8, 9.6.6, 9.8.4, 9.10.1, 9.12.1 }
+tested-with:         GHC == { 8.10.7, 9.0.2, 9.2.8, 9.4.8, 9.6.6, 9.8.4, 9.10.1, 9.12.2 }
 
 Source-repository head
   type:     git


### PR DESCRIPTION
This PR proposes to regenerate the `haskell-ci.yml` (using the latest available version https://github.com/haskell-CI/haskell-ci/commit/41d6548a0d5595d0dbab0677cfca37ed025c9cfe), primarily to bump the `ubuntu` image version used in the GitHub CI.