### PR TITLE
log-elasticsearch: switch back to http-client-tls by default

### DIFF
--- a/log-elasticsearch/CHANGELOG.md
+++ b/log-elasticsearch/CHANGELOG.md
@@ -1,4 +1,4 @@
-# log-elasticsearch-0.13.1.0 (2025-04-01)
+# log-elasticsearch-0.13.0.2 (2025-04-01)
 * Switch back to `http-client-tls` by default, and add a constraint
   on a more recent version.
 

--- a/log-elasticsearch/CHANGELOG.md
+++ b/log-elasticsearch/CHANGELOG.md
@@ -1,3 +1,7 @@
+# log-elasticsearch-0.13.1.0 (2025-04-01)
+* Switch back to `http-client-tls` by default, and add a constraint
+  on a more recent version.
+
 # log-elasticsearch-0.13.0.1 (2023-01-31)
 * Add support for OpenSearch.
 

--- a/log-elasticsearch/log-elasticsearch.cabal
+++ b/log-elasticsearch/log-elasticsearch.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                log-elasticsearch
-version:             0.13.1.0
+version:             0.13.0.2
 synopsis:            Structured logging solution (Elasticsearch back end)
 
 description:         Elasticsearch back end for the 'log' library suite.

--- a/log-elasticsearch/log-elasticsearch.cabal
+++ b/log-elasticsearch/log-elasticsearch.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                log-elasticsearch
-version:             0.13.0.1
+version:             0.13.1.0
 synopsis:            Structured logging solution (Elasticsearch back end)
 
 description:         Elasticsearch back end for the 'log' library suite.
@@ -26,7 +26,7 @@ source-repository head
 
 flag openssl
   description:   Use http-client-openssl instead of http-client-tls
-  default:       True
+  default:       False
 
 library
   exposed-modules:     Log.Backend.ElasticSearch
@@ -73,4 +73,4 @@ library
     cpp-options: -DOPENSSL
     build-depends: http-client-openssl >= 0.3.2
   else
-    build-depends: http-client-tls
+    build-depends: http-client-tls >= 0.3.6.3


### PR DESCRIPTION
This PR proposes to switch back to `http-client-tls` by default.
The `http-client-openssl` package depends on `HsOpenSSL` that still depends on OpenSSL APIs that should be removed in the short/medium term [1]. So let's use `http-client-tls` for now.

[1] https://github.com/haskell-cryptography/HsOpenSSL/issues/95